### PR TITLE
Test PR labeler on a python directory for a non .py file - Old config that shows that ! operator won't work as is.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,20 +32,20 @@ INFRA:
   - "/dev/run-tests-jenkins*"
 # BUILD has been updated with some lingering questions
 BUILD:
-  - any:
-    - "/dev/**/*"
-    - "/build/**/*"
-    - "/project/**/*"
-    - "/assembly/**/*"
-    - "**/*pom.xml"
-    - "/bin/docker-image-tool.sh"
-    - "/bin/find-spark-home*"
-    - "scalastyle-config.xml"
-  - all:
-    - "!/dev/github_jira_sync.py"
-    - "!/dev/merge_spark_pr.py"
-    - "!/dev/run-tests-jenkins*"
-    - "!/dev/.rat-excludes"
+- any:
+  - "/dev/**/*"
+  - "/build/**/*"
+  - "/project/**/*"
+  - "/assembly/**/*"
+  - "**/*pom.xml"
+  - "/bin/docker-image-tool.sh"
+  - "/bin/find-spark-home*"
+  - "scalastyle-config.xml"
+- all:
+  - "!/dev/github_jira_sync.py"
+  - "!/dev/merge_spark_pr.py"
+  - "!/dev/run-tests-jenkins*"
+  - "!/dev/.rat-excludes"
 # DOCS has been updated - Need to test if the repo root README will catch
 DOCS:
   - "docs/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,86 +54,101 @@ DOCS:
 EXAMPLES:
   - "examples/**/*"
   - "/bin/run-example*"
+# Core has been updated with some verification needed.
 CORE:
-  - "/core/"
-  - "!UI.scala"
-  - "!ui/"
-  - "/common/kvstore/"
-  - "/common/network-common/"
-  - "/common/network-shuffle/"
-  - "/python/pyspark/*.py"
-  - "/python/pyspark/tests/*.py"
+  - "/core/**/*"
+  - "!**/UI.scala"  # TODO - Verify this change
+  - "!**/ui/**/*"  # TODO - Verify this change
+  - "/common/kvstore/**/*"
+  - "/common/network-common/**/*"
+  - "/common/network-shuffle/**/*"
+  - "/python/pyspark/**/*.py"  # TODO - Do we ned one more glob for subdirs?
+  - "/python/pyspark/tests/**/*.py"  # TODO - Same as above.
+# Updated
 SPARK SUBMIT:
   - "/bin/spark-submit*"
+# Updated
 SPARK SHELL:
-  - "/repl/"
+  - "/repl/**/*"
   - "/bin/spark-shell*"
+# Updated - Needs testing
 SQL:
-  - "sql/"
-  - "/common/unsafe/"
-  - "!/python/pyspark/sql/avro/"
+  - "**/sql/**/*"  # TODO - Need to verify intermediate directories
+  - "/common/unsafe/**/*"
+  - "!/python/pyspark/sql/avro/**/*"
   - "!/python/pyspark/sql/streaming.py"
   - "!/python/pyspark/sql/tests/test_streaming.py"
   - "/bin/spark-sql*"
   - "/bin/beeline*"
   - "/sbin/*thriftserver*.sh"
-  - "*SQL*.R"
-  - "DataFrame.R"
-  - "WindowSpec.R"
-  - "catalog.R"
-  - "column.R"
-  - "functions.R"
-  - "group.R"
-  - "schema.R"
-  - "types.R"
+  - "**/*SQL*.R"  # TODO - Verify this one
+  - "**/*/DataFrame.R"  # TODO - Verify this one
+  - "**/*/WindowSpec.R"  # TODO - Verify all the rest
+  - "**/*catalog.R"
+  - "**/*column.R"
+  - "**/*functions.R"
+  - "**/*group.R"
+  - "**/*schema.R"
+  - "**/*types.R"
+# Updated
 AVRO:
-  - "/external/avro/"
-  - "/python/pyspark/sql/avro/"
+  - "/external/avro/**/*"
+  - "/python/pyspark/sql/avro/**/*"
+# Updated
 DSTREAM:
-  - "/streaming/"
-  - "/data/streaming/"
-  - "/external/flume*"
-  - "/external/kinesis*"
-  - "/external/kafka*"
-  - "/python/pyspark/streaming/"
+  - "/streaming/**/*"
+  - "/data/streaming/**/*"
+  - "/external/flume*"  # TODO - Does this need to be /external/flume*/**/*?
+  - "/external/kinesis*"  # TODO - Same as above
+  - "/external/kafka*"  # TODO - Same as above
+  - "/python/pyspark/streaming/**/*"
+# Updated
 GRAPHX:
-  - "/graphx/"
-  - "/data/graphx/"
+  - "/graphx/**/*"
+  - "/data/graphx/**/*"
+# Updated
 ML:
-  - "ml/"
-  - "*mllib_*.R"
+  - "**/ml/**/*"
+  - "**/*mllib_*.R"
 MLLIB:
-  - "spark/mllib/"
-  - "/mllib-local/"
-  - "/python/pyspark/mllib/"
+  - "**/spark/mllib/"  # TODO - Is it intentional to not label mllib/benchmarks/* as MLLIB, etc?
+  - "/mllib-local/**/*"
+  - "/python/pyspark/mllib/**/*"
 STRUCTURED STREAMING:
-  - "sql/**/streaming/"
-  - "/external/kafka-0-10-sql/"
+  - "sql/**/streaming/"  # TODO - Does this one need editing?
+  - "/external/kafka-0-10-sql/**/*"
   - "/python/pyspark/sql/streaming.py"
   - "/python/pyspark/sql/tests/test_streaming.py"
-  - "*streaming.R"
+  - "**/*streaming.R"
+# Updated - Needs tests
 PYTHON:
   - "/bin/pyspark*"
-  - "python/"
+  - "**/python/**/*"  # TODO - Check this glob - was "python/"
 R:
   - "r/"
   - "R/"
   - "/bin/sparkR*"
+# Updated - Needs tests
 YARN:
-  - "/resource-managers/yarn/"
+  - "/resource-managers/yarn/**/*"
+# Updated
 MESOS:
-  - "/resource-managers/mesos/"
+  - "/resource-managers/mesos/**/*"
   - "/sbin/*mesos*.sh"
+# Updated
 KUBERNETES:
-  - "/resource-managers/kubernetes/"
+  - "/resource-managers/kubernetes/**/*"
+# Updated - Should test cmd
 WINDOWS:
-  - "*.cmd"
+  - "**/*.cmd"
   - "/R/pkg/tests/fulltests/test_Windows.R"
+# Updated - first glob needs testing
 WEB UI:
-  - "ui/"
-  - "UI.scala"
+  - "**/ui/**/*"
+  - "**/UI.scala"
+# Updated
 DEPLOY:
-  - "/sbin/"
+  - "/sbin/**/*"
 
 
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -38,18 +38,18 @@ BUILD:
   - "!/dev/merge_spark_pr.py"
   - "!/dev/run-tests-jenkins*"
   - "!/dev/.rat-excludes"
-  - "/build/*"  # TODO - This currently has no nested structures, should we account for potential nested folders in the future?
-  - "/project/*"  # TODO - Same note as above
-  - "/assembly/*"  # TODO - Same note as above
+  - "/build/**/*"
+  - "/project/**/*"
+  - "/assembly/**/*"
   - "**/*pom.xml"
   - "/bin/docker-image-tool.sh"
   - "/bin/find-spark-home*"
   - "scalastyle-config.xml"
-# DOCS has been updated but with some needed tests
+# DOCS has been updated - Need to test if the repo root README will catch
 DOCS:
   - "docs/**/*"
-  - "**/README.md"  # TODO - Verify this matches on a nested README
-  - "**/CONTRIBUTING.md"  # TODO - Same as above
+  - "**/README.md"
+  - "**/CONTRIBUTING.md"
 # EXAMPLES has been updated
 EXAMPLES:
   - "examples/**/*"
@@ -62,8 +62,8 @@ CORE:
   - "/common/kvstore/**/*"
   - "/common/network-common/**/*"
   - "/common/network-shuffle/**/*"
-  - "/python/pyspark/**/*.py"  # TODO - Do we ned one more glob for subdirs?
-  - "/python/pyspark/tests/**/*.py"  # TODO - Same as above.
+  - "/python/pyspark/**/*.py"
+  - "/python/pyspark/tests/**/*.py"
 # Updated
 SPARK SUBMIT:
   - "/bin/spark-submit*"
@@ -73,7 +73,7 @@ SPARK SHELL:
   - "/bin/spark-shell*"
 # Updated - Needs testing
 SQL:
-  - "**/sql/**/*"  # TODO - Need to verify intermediate directories
+  - "**/sql/**/*"
   - "/common/unsafe/**/*"
   - "!/python/pyspark/sql/avro/**/*"
   - "!/python/pyspark/sql/streaming.py"
@@ -81,9 +81,9 @@ SQL:
   - "/bin/spark-sql*"
   - "/bin/beeline*"
   - "/sbin/*thriftserver*.sh"
-  - "**/*SQL*.R"  # TODO - Verify this one
-  - "**/*/DataFrame.R"  # TODO - Verify this one
-  - "**/*/WindowSpec.R"  # TODO - Verify all the rest
+  - "**/*SQL*.R"
+  - "**/*DataFrame.R"  # TODO - Does ths need a star before DataFrame?
+  - "**/*WindowSpec.R"
   - "**/*catalog.R"
   - "**/*column.R"
   - "**/*functions.R"
@@ -98,7 +98,7 @@ AVRO:
 DSTREAM:
   - "/streaming/**/*"
   - "/data/streaming/**/*"
-  - "/external/flume*"  # TODO - Does this need to be /external/flume*/**/*?
+  - "/external/flume*"  # TODO - Does this need to be /external/flume*/**/*? Need to test this
   - "/external/kinesis*"  # TODO - Same as above
   - "/external/kafka*"  # TODO - Same as above
   - "/python/pyspark/streaming/**/*"
@@ -115,7 +115,7 @@ MLLIB:
   - "/mllib-local/**/*"
   - "/python/pyspark/mllib/**/*"
 STRUCTURED STREAMING:
-  - "sql/**/streaming/"  # TODO - Does this one need editing?
+  - "sql/**/streaming/**/*"  # TODO - Does this one need a leading **/ editing?
   - "/external/kafka-0-10-sql/**/*"
   - "/python/pyspark/sql/streaming.py"
   - "/python/pyspark/sql/tests/test_streaming.py"
@@ -124,9 +124,10 @@ STRUCTURED STREAMING:
 PYTHON:
   - "/bin/pyspark*"
   - "**/python/**/*"  # TODO - Check this glob - was "python/"
+# Updated - Needs tests
 R:
-  - "r/"
-  - "R/"
+  - "**/r/**/*"
+  - "**/R/**/*"  # TODO - Do these need also one for non-nested
   - "/bin/sparkR*"
 # Updated - Needs tests
 YARN:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,18 +32,20 @@ INFRA:
   - "/dev/run-tests-jenkins*"
 # BUILD has been updated with some lingering questions
 BUILD:
-  - "/dev/**/*"
-  - "!/dev/github_jira_sync.py"
-  - "!/dev/merge_spark_pr.py"
-  - "!/dev/run-tests-jenkins*"
-  - "!/dev/.rat-excludes"
-  - "/build/**/*"
-  - "/project/**/*"
-  - "/assembly/**/*"
-  - "**/*pom.xml"
-  - "/bin/docker-image-tool.sh"
-  - "/bin/find-spark-home*"
-  - "scalastyle-config.xml"
+  - any:
+    - "/dev/**/*"
+    - "/build/**/*"
+    - "/project/**/*"
+    - "/assembly/**/*"
+    - "**/*pom.xml"
+    - "/bin/docker-image-tool.sh"
+    - "/bin/find-spark-home*"
+    - "scalastyle-config.xml"
+  - all:
+    - "!/dev/github_jira_sync.py"
+    - "!/dev/merge_spark_pr.py"
+    - "!/dev/run-tests-jenkins*"
+    - "!/dev/.rat-excludes"
 # DOCS has been updated - Need to test if the repo root README will catch
 DOCS:
   - "docs/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,191 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Pull Request Labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
+
+### FOLLOWING IS THE OLD probot autolabeler config that needs to be updated
+# Infra has been updated
+INFRA:
+  - ".github/**/*"
+  - "appveyor.yml"
+  - "tools/**/*"
+  - "/dev/create-release/**/*"
+  - ".asf.yaml"
+  - ".gitattributes"
+  - ".gitignore"
+  - "/dev/github_jira_sync.py"
+  - "/dev/merge_spark_pr.py"
+  - "/dev/run-tests-jenkins*"
+BUILD:
+  - "/dev/"
+  - "!/dev/github_jira_sync.py"
+  - "!/dev/merge_spark_pr.py"
+  - "!/dev/run-tests-jenkins*"
+  - "!/dev/.rat-excludes"
+  - "/build/"
+  - "/project/"
+  - "/assembly/"
+  - "*pom.xml"
+  - "/bin/docker-image-tool.sh"
+  - "/bin/find-spark-home*"
+  - "scalastyle-config.xml"
+DOCS:
+  - "docs/"
+  - "/README.md"
+  - "/CONTRIBUTING.md"
+EXAMPLES:
+  - "examples/"
+  - "/bin/run-example*"
+CORE:
+  - "/core/"
+  - "!UI.scala"
+  - "!ui/"
+  - "/common/kvstore/"
+  - "/common/network-common/"
+  - "/common/network-shuffle/"
+  - "/python/pyspark/*.py"
+  - "/python/pyspark/tests/*.py"
+SPARK SUBMIT:
+  - "/bin/spark-submit*"
+SPARK SHELL:
+  - "/repl/"
+  - "/bin/spark-shell*"
+SQL:
+  - "sql/"
+  - "/common/unsafe/"
+  - "!/python/pyspark/sql/avro/"
+  - "!/python/pyspark/sql/streaming.py"
+  - "!/python/pyspark/sql/tests/test_streaming.py"
+  - "/bin/spark-sql*"
+  - "/bin/beeline*"
+  - "/sbin/*thriftserver*.sh"
+  - "*SQL*.R"
+  - "DataFrame.R"
+  - "WindowSpec.R"
+  - "catalog.R"
+  - "column.R"
+  - "functions.R"
+  - "group.R"
+  - "schema.R"
+  - "types.R"
+AVRO:
+  - "/external/avro/"
+  - "/python/pyspark/sql/avro/"
+DSTREAM:
+  - "/streaming/"
+  - "/data/streaming/"
+  - "/external/flume*"
+  - "/external/kinesis*"
+  - "/external/kafka*"
+  - "/python/pyspark/streaming/"
+GRAPHX:
+  - "/graphx/"
+  - "/data/graphx/"
+ML:
+  - "ml/"
+  - "*mllib_*.R"
+MLLIB:
+  - "spark/mllib/"
+  - "/mllib-local/"
+  - "/python/pyspark/mllib/"
+STRUCTURED STREAMING:
+  - "sql/**/streaming/"
+  - "/external/kafka-0-10-sql/"
+  - "/python/pyspark/sql/streaming.py"
+  - "/python/pyspark/sql/tests/test_streaming.py"
+  - "*streaming.R"
+PYTHON:
+  - "/bin/pyspark*"
+  - "python/"
+R:
+  - "r/"
+  - "R/"
+  - "/bin/sparkR*"
+YARN:
+  - "/resource-managers/yarn/"
+MESOS:
+  - "/resource-managers/mesos/"
+  - "/sbin/*mesos*.sh"
+KUBERNETES:
+  - "/resource-managers/kubernetes/"
+WINDOWS:
+  - "*.cmd"
+  - "/R/pkg/tests/fulltests/test_Windows.R"
+WEB UI:
+  - "ui/"
+  - "UI.scala"
+DEPLOY:
+  - "/sbin/"
+
+
+
+#### TAKEN FROM ICEBERG LABELER AS A REFERENCE
+INFRA:
+  - .asf.yaml
+  - .gitattributes
+  - .gitignore
+  - baseline.gradle
+  - deploy.gradle
+  - jitpack.yml
+  - travis.yml
+  - .baseline/**/*
+  - .github/**/*
+  - dev/**/*
+BUILD:
+  - "**/*gradle*"
+  - versions.props
+DOCS:
+  - site/**/*
+  - "**/*CHANGELOG.md"
+  - "**/*README.md"
+EXAMPLES:
+  - examples/**/*
+COMMON:
+  - common/**/*
+API:
+  - api/**/*
+CORE:
+  - core/**/*
+PYTHON:
+  - python/**/*
+PARQUET:
+  - parquet/**/*
+ARROW:
+  - arrow/**/*
+ORC:
+  - orc/**/*
+HIVE:
+  - hive3/**/*
+  - hive-metastore/**/*
+  - hive-runtime/**/*
+DATA:
+  - data/**/*
+SPARK:
+  - spark-runtime/**/*
+  - spark3-runtime/**/*
+  - spark/**/*
+  - spark2/**/*
+  - spark3/**/*
+FLINK:
+  - flink-runtime/**/*
+  - flink/**/*
+MR:
+  - mr/**/*
+PIG:
+  - pig/**/*
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,21 +31,21 @@ INFRA:
   - "/dev/merge_spark_pr.py"
   - "/dev/run-tests-jenkins*"
 # BUILD has been updated with some lingering questions
-BUILD:
-- any:
-  - "/dev/**/*"
-  - "/build/**/*"
-  - "/project/**/*"
-  - "/assembly/**/*"
-  - "**/*pom.xml"
-  - "/bin/docker-image-tool.sh"
-  - "/bin/find-spark-home*"
-  - "scalastyle-config.xml"
-- all:
-  - "!/dev/github_jira_sync.py"
-  - "!/dev/merge_spark_pr.py"
-  - "!/dev/run-tests-jenkins*"
-  - "!/dev/.rat-excludes"
+#BUILD:
+#- any:
+#  - "/dev/**/*"
+#  - "/build/**/*"
+#  - "/project/**/*"
+#  - "/assembly/**/*"
+#  - "**/*pom.xml"
+#  - "/bin/docker-image-tool.sh"
+#  - "/bin/find-spark-home*"
+#  - "scalastyle-config.xml"
+#- all:
+#  - "!/dev/github_jira_sync.py"
+#  - "!/dev/merge_spark_pr.py"
+#  - "!/dev/run-tests-jenkins*"
+#  - "!/dev/.rat-excludes"
 # DOCS has been updated - Need to test if the repo root README will catch
 DOCS:
   - "docs/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -139,72 +139,14 @@ MESOS:
 # Updated
 KUBERNETES:
   - "/resource-managers/kubernetes/**/*"
-# Updated - Should test cmd
+# Updated
 WINDOWS:
   - "**/*.cmd"
   - "/R/pkg/tests/fulltests/test_Windows.R"
-# Updated - first glob needs testing
+# Updated
 WEB UI:
   - "**/ui/**/*"
-  - "**/UI.scala"
+  - "**/*UI.scala"
 # Updated
 DEPLOY:
   - "/sbin/**/*"
-
-
-
-#### TAKEN FROM ICEBERG LABELER AS A REFERENCE
-INFRA:
-  - .asf.yaml
-  - .gitattributes
-  - .gitignore
-  - baseline.gradle
-  - deploy.gradle
-  - jitpack.yml
-  - travis.yml
-  - .baseline/**/*
-  - .github/**/*
-  - dev/**/*
-BUILD:
-  - "**/*gradle*"
-  - versions.props
-DOCS:
-  - site/**/*
-  - "**/*CHANGELOG.md"
-  - "**/*README.md"
-EXAMPLES:
-  - examples/**/*
-COMMON:
-  - common/**/*
-API:
-  - api/**/*
-CORE:
-  - core/**/*
-PYTHON:
-  - python/**/*
-PARQUET:
-  - parquet/**/*
-ARROW:
-  - arrow/**/*
-ORC:
-  - orc/**/*
-HIVE:
-  - hive3/**/*
-  - hive-metastore/**/*
-  - hive-runtime/**/*
-DATA:
-  - data/**/*
-SPARK:
-  - spark-runtime/**/*
-  - spark3-runtime/**/*
-  - spark/**/*
-  - spark2/**/*
-  - spark3/**/*
-FLINK:
-  - flink-runtime/**/*
-  - flink/**/*
-MR:
-  - mr/**/*
-PIG:
-  - pig/**/*
-

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,7 +19,7 @@
 # Pull Request Labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
 
 ### FOLLOWING IS THE OLD probot autolabeler config that needs to be updated
-# Infra has been updated
+# INFRA has been updated
 INFRA:
   - ".github/**/*"
   - "appveyor.yml"
@@ -31,25 +31,28 @@ INFRA:
   - "/dev/github_jira_sync.py"
   - "/dev/merge_spark_pr.py"
   - "/dev/run-tests-jenkins*"
+# BUILD has been updated with some lingering questions
 BUILD:
-  - "/dev/"
+  - "/dev/**/*"
   - "!/dev/github_jira_sync.py"
   - "!/dev/merge_spark_pr.py"
   - "!/dev/run-tests-jenkins*"
   - "!/dev/.rat-excludes"
-  - "/build/"
-  - "/project/"
-  - "/assembly/"
-  - "*pom.xml"
+  - "/build/*"  # TODO - This currently has no nested structures, should we account for potential nested folders in the future?
+  - "/project/*"  # TODO - Same note as above
+  - "/assembly/*"  # TODO - Same note as above
+  - "**/*pom.xml"
   - "/bin/docker-image-tool.sh"
   - "/bin/find-spark-home*"
   - "scalastyle-config.xml"
+# DOCS has been updated but with some needed tests
 DOCS:
-  - "docs/"
-  - "/README.md"
-  - "/CONTRIBUTING.md"
+  - "docs/**/*"
+  - "**/README.md"  # TODO - Verify this matches on a nested README
+  - "**/CONTRIBUTING.md"  # TODO - Same as above
+# EXAMPLES has been updated
 EXAMPLES:
-  - "examples/"
+  - "examples/**/*"
   - "/bin/run-example*"
 CORE:
   - "/core/"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,7 +18,6 @@
 #
 # Pull Request Labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
 
-### FOLLOWING IS THE OLD probot autolabeler config that needs to be updated
 # INFRA has been updated
 INFRA:
   - ".github/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -112,7 +112,7 @@ ML:
   - "**/ml/**/*"
   - "**/*mllib_*.R"
 MLLIB:
-  - "**/spark/mllib/"  # TODO - Is it intentional to not label mllib/benchmarks/* as MLLIB, etc?
+  - "**/spark/mllib/**/*"
   - "/mllib-local/**/*"
   - "/python/pyspark/mllib/**/*"
 STRUCTURED STREAMING:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,6 +14,14 @@ on:
         required: true
 
 jobs:
+  # Cancel previusly queued or in_progress workflows if there's a push to the PR
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
   # Build: build Spark and run the tests for specified modules.
   build:
     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,429 +1,429 @@
-name: Build and test
+# name: Build and test
 
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
-  workflow_dispatch:
-    inputs:
-      target:
-        description: 'Target branch to run'
-        required: true
+# on:
+#   push:
+#     branches:
+#     - master
+#   pull_request:
+#     branches:
+#     - master
+#   workflow_dispatch:
+#     inputs:
+#       target:
+#         description: 'Target branch to run'
+#         required: true
 
-jobs:
-  # Cancel previusly queued or in_progress workflows if there's a push to the PR
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-  # Build: build Spark and run the tests for specified modules.
-  build:
-    name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
-    # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        java:
-          - 1.8
-        hadoop:
-          - hadoop3.2
-        hive:
-          - hive2.3
-        # TODO(SPARK-32246): We don't test 'streaming-kinesis-asl' for now.
-        # Kinesis tests depends on external Amazon kinesis service.
-        # Note that the modules below are from sparktestsupport/modules.py.
-        modules:
-          - >-
-            core, unsafe, kvstore, avro,
-            network-common, network-shuffle, repl, launcher,
-            examples, sketch, graphx
-          - >-
-            catalyst, hive-thriftserver
-          - >-
-            streaming, sql-kafka-0-10, streaming-kafka-0-10,
-            mllib-local, mllib,
-            yarn, mesos, kubernetes, hadoop-cloud, spark-ganglia-lgpl
-        # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
-        included-tags: [""]
-        excluded-tags: [""]
-        comment: [""]
-        include:
-          # Hive tests
-          - modules: hive
-            java: 1.8
-            hadoop: hadoop3.2
-            hive: hive2.3
-            included-tags: org.apache.spark.tags.SlowHiveTest
-            comment: "- slow tests"
-          - modules: hive
-            java: 1.8
-            hadoop: hadoop3.2
-            hive: hive2.3
-            excluded-tags: org.apache.spark.tags.SlowHiveTest
-            comment: "- other tests"
-          # SQL tests
-          - modules: sql
-            java: 1.8
-            hadoop: hadoop3.2
-            hive: hive2.3
-            included-tags: org.apache.spark.tags.ExtendedSQLTest
-            comment: "- slow tests"
-          - modules: sql
-            java: 1.8
-            hadoop: hadoop3.2
-            hive: hive2.3
-            excluded-tags: org.apache.spark.tags.ExtendedSQLTest
-            comment: "- other tests"
-    env:
-      MODULES_TO_TEST: ${{ matrix.modules }}
-      EXCLUDED_TAGS: ${{ matrix.excluded-tags }}
-      INCLUDED_TAGS: ${{ matrix.included-tags }}
-      HADOOP_PROFILE: ${{ matrix.hadoop }}
-      HIVE_PROFILE: ${{ matrix.hive }}
-      # GitHub Actions' default miniconda to use in pip packaging test.
-      CONDA_PREFIX: /usr/share/miniconda
-      GITHUB_PREV_SHA: ${{ github.event.before }}
-      GITHUB_INPUT_BRANCH: ${{ github.event.inputs.target }}
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
-      with:
-        fetch-depth: 0
-    - name: Merge dispatched input branch
-      if: ${{ github.event.inputs.target != '' }}
-      run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache Scala, SBT, Maven and Zinc
-      uses: actions/cache@v2
-      with:
-        path: |
-          build/apache-maven-*
-          build/zinc-*
-          build/scala-*
-          build/*.jar
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
-        restore-keys: |
-          build-
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ matrix.java }}-${{ matrix.hadoop }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ matrix.java }}-${{ matrix.hadoop }}-maven-
-    - name: Cache Ivy local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.ivy2/cache
-        key: ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-
-    - name: Install JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
-    - name: Install Python 3.8
-      uses: actions/setup-python@v2
-      # We should install one Python that is higher then 3+ for SQL and Yarn because:
-      # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
-      # - Yarn has a Python specific test too, for example, YarnClusterSuite.
-      if: contains(matrix.modules, 'yarn') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
-      with:
-        python-version: 3.8
-        architecture: x64
-    - name: Install Python packages (Python 3.8)
-      if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
-      run: |
-        python3.8 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
-        python3.8 -m pip list
-    # Run the tests.
-    - name: Run tests
-      run: |
-        # Hive tests become flaky when running in parallel as it's too intensive.
-        if [[ "$MODULES_TO_TEST" == "hive" ]]; then export SERIAL_SBT_TESTS=1; fi
-        mkdir -p ~/.m2
-        ./dev/run-tests --parallelism 2 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
-        rm -rf ~/.m2/repository/org/apache/spark
-    - name: Upload test results to report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
-        path: "**/target/test-reports/*.xml"
-    - name: Upload unit tests log files
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
-        path: "**/target/unit-tests.log"
+# jobs:
+#   # Cancel previusly queued or in_progress workflows if there's a push to the PR
+#   test:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Cancel Previous Runs
+#         uses: styfle/cancel-workflow-action@0.6.0
+#         with:
+#           access_token: ${{ github.token }}
+#   # Build: build Spark and run the tests for specified modules.
+#   build:
+#     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
+#     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
+#     runs-on: ubuntu-20.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         java:
+#           - 1.8
+#         hadoop:
+#           - hadoop3.2
+#         hive:
+#           - hive2.3
+#         # TODO(SPARK-32246): We don't test 'streaming-kinesis-asl' for now.
+#         # Kinesis tests depends on external Amazon kinesis service.
+#         # Note that the modules below are from sparktestsupport/modules.py.
+#         modules:
+#           - >-
+#             core, unsafe, kvstore, avro,
+#             network-common, network-shuffle, repl, launcher,
+#             examples, sketch, graphx
+#           - >-
+#             catalyst, hive-thriftserver
+#           - >-
+#             streaming, sql-kafka-0-10, streaming-kafka-0-10,
+#             mllib-local, mllib,
+#             yarn, mesos, kubernetes, hadoop-cloud, spark-ganglia-lgpl
+#         # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
+#         included-tags: [""]
+#         excluded-tags: [""]
+#         comment: [""]
+#         include:
+#           # Hive tests
+#           - modules: hive
+#             java: 1.8
+#             hadoop: hadoop3.2
+#             hive: hive2.3
+#             included-tags: org.apache.spark.tags.SlowHiveTest
+#             comment: "- slow tests"
+#           - modules: hive
+#             java: 1.8
+#             hadoop: hadoop3.2
+#             hive: hive2.3
+#             excluded-tags: org.apache.spark.tags.SlowHiveTest
+#             comment: "- other tests"
+#           # SQL tests
+#           - modules: sql
+#             java: 1.8
+#             hadoop: hadoop3.2
+#             hive: hive2.3
+#             included-tags: org.apache.spark.tags.ExtendedSQLTest
+#             comment: "- slow tests"
+#           - modules: sql
+#             java: 1.8
+#             hadoop: hadoop3.2
+#             hive: hive2.3
+#             excluded-tags: org.apache.spark.tags.ExtendedSQLTest
+#             comment: "- other tests"
+#     env:
+#       MODULES_TO_TEST: ${{ matrix.modules }}
+#       EXCLUDED_TAGS: ${{ matrix.excluded-tags }}
+#       INCLUDED_TAGS: ${{ matrix.included-tags }}
+#       HADOOP_PROFILE: ${{ matrix.hadoop }}
+#       HIVE_PROFILE: ${{ matrix.hive }}
+#       # GitHub Actions' default miniconda to use in pip packaging test.
+#       CONDA_PREFIX: /usr/share/miniconda
+#       GITHUB_PREV_SHA: ${{ github.event.before }}
+#       GITHUB_INPUT_BRANCH: ${{ github.event.inputs.target }}
+#     steps:
+#     - name: Checkout Spark repository
+#       uses: actions/checkout@v2
+#       # In order to fetch changed files
+#       with:
+#         fetch-depth: 0
+#     - name: Merge dispatched input branch
+#       if: ${{ github.event.inputs.target != '' }}
+#       run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
+#     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+#     - name: Cache Scala, SBT, Maven and Zinc
+#       uses: actions/cache@v2
+#       with:
+#         path: |
+#           build/apache-maven-*
+#           build/zinc-*
+#           build/scala-*
+#           build/*.jar
+#         key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+#         restore-keys: |
+#           build-
+#     - name: Cache Maven local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.m2/repository
+#         key: ${{ matrix.java }}-${{ matrix.hadoop }}-maven-${{ hashFiles('**/pom.xml') }}
+#         restore-keys: |
+#           ${{ matrix.java }}-${{ matrix.hadoop }}-maven-
+#     - name: Cache Ivy local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.ivy2/cache
+#         key: ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+#         restore-keys: |
+#           ${{ matrix.java }}-${{ matrix.hadoop }}-ivy-
+#     - name: Install JDK ${{ matrix.java }}
+#       uses: actions/setup-java@v1
+#       with:
+#         java-version: ${{ matrix.java }}
+#     - name: Install Python 3.8
+#       uses: actions/setup-python@v2
+#       # We should install one Python that is higher then 3+ for SQL and Yarn because:
+#       # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
+#       # - Yarn has a Python specific test too, for example, YarnClusterSuite.
+#       if: contains(matrix.modules, 'yarn') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
+#       with:
+#         python-version: 3.8
+#         architecture: x64
+#     - name: Install Python packages (Python 3.8)
+#       if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
+#       run: |
+#         python3.8 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
+#         python3.8 -m pip list
+#     # Run the tests.
+#     - name: Run tests
+#       run: |
+#         # Hive tests become flaky when running in parallel as it's too intensive.
+#         if [[ "$MODULES_TO_TEST" == "hive" ]]; then export SERIAL_SBT_TESTS=1; fi
+#         mkdir -p ~/.m2
+#         ./dev/run-tests --parallelism 2 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
+#         rm -rf ~/.m2/repository/org/apache/spark
+#     - name: Upload test results to report
+#       if: always()
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: test-results-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
+#         path: "**/target/test-reports/*.xml"
+#     - name: Upload unit tests log files
+#       if: failure()
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
+#         path: "**/target/unit-tests.log"
 
-  pyspark:
-    name: "Build modules: ${{ matrix.modules }}"
-    runs-on: ubuntu-20.04
-    container:
-      image: dongjoon/apache-spark-github-action-image:20201015
-    strategy:
-      fail-fast: false
-      matrix:
-        modules:
-          - >-
-            pyspark-sql, pyspark-mllib, pyspark-resource
-          - >-
-            pyspark-core, pyspark-streaming, pyspark-ml
-    env:
-      MODULES_TO_TEST: ${{ matrix.modules }}
-      HADOOP_PROFILE: hadoop3.2
-      HIVE_PROFILE: hive2.3
-      # GitHub Actions' default miniconda to use in pip packaging test.
-      CONDA_PREFIX: /usr/share/miniconda
-      GITHUB_PREV_SHA: ${{ github.event.before }}
-      GITHUB_INPUT_BRANCH: ${{ github.event.inputs.target }}
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
-      with:
-        fetch-depth: 0
-    - name: Merge dispatched input branch
-      if: ${{ github.event.inputs.target != '' }}
-      run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache Scala, SBT, Maven and Zinc
-      uses: actions/cache@v2
-      with:
-        path: |
-          build/apache-maven-*
-          build/zinc-*
-          build/scala-*
-          build/*.jar
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
-        restore-keys: |
-          build-
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: pyspark-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          pyspark-maven-
-    - name: Cache Ivy local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.ivy2/cache
-        key: pyspark-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          pyspark-ivy-
-    - name: Install Python 3.6
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
-        architecture: x64
-    # This step takes much less time (~30s) than other Python versions so it is not included
-    # in the Docker image being used. There is also a technical issue to install Python 3.6 on
-    # Ubuntu 20.04. See also SPARK-33162.
-    - name: Install Python packages (Python 3.6)
-      run: |
-        python3.6 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
-        python3.6 -m pip list
-    # Run the tests.
-    - name: Run tests
-      run: |
-        mkdir -p ~/.m2
-        ./dev/run-tests --parallelism 2 --modules "$MODULES_TO_TEST"
-        rm -rf ~/.m2/repository/org/apache/spark
-    - name: Upload test results to report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-${{ matrix.modules }}--1.8-hadoop3.2-hive2.3
-        path: "**/target/test-reports/*.xml"
-    - name: Upload unit tests log files
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: unit-tests-log-${{ matrix.modules }}--1.8-hadoop3.2-hive2.3
-        path: "**/target/unit-tests.log"
+#   pyspark:
+#     name: "Build modules: ${{ matrix.modules }}"
+#     runs-on: ubuntu-20.04
+#     container:
+#       image: dongjoon/apache-spark-github-action-image:20201015
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         modules:
+#           - >-
+#             pyspark-sql, pyspark-mllib, pyspark-resource
+#           - >-
+#             pyspark-core, pyspark-streaming, pyspark-ml
+#     env:
+#       MODULES_TO_TEST: ${{ matrix.modules }}
+#       HADOOP_PROFILE: hadoop3.2
+#       HIVE_PROFILE: hive2.3
+#       # GitHub Actions' default miniconda to use in pip packaging test.
+#       CONDA_PREFIX: /usr/share/miniconda
+#       GITHUB_PREV_SHA: ${{ github.event.before }}
+#       GITHUB_INPUT_BRANCH: ${{ github.event.inputs.target }}
+#     steps:
+#     - name: Checkout Spark repository
+#       uses: actions/checkout@v2
+#       # In order to fetch changed files
+#       with:
+#         fetch-depth: 0
+#     - name: Merge dispatched input branch
+#       if: ${{ github.event.inputs.target != '' }}
+#       run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
+#     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+#     - name: Cache Scala, SBT, Maven and Zinc
+#       uses: actions/cache@v2
+#       with:
+#         path: |
+#           build/apache-maven-*
+#           build/zinc-*
+#           build/scala-*
+#           build/*.jar
+#         key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+#         restore-keys: |
+#           build-
+#     - name: Cache Maven local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.m2/repository
+#         key: pyspark-maven-${{ hashFiles('**/pom.xml') }}
+#         restore-keys: |
+#           pyspark-maven-
+#     - name: Cache Ivy local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.ivy2/cache
+#         key: pyspark-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+#         restore-keys: |
+#           pyspark-ivy-
+#     - name: Install Python 3.6
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: 3.6
+#         architecture: x64
+#     # This step takes much less time (~30s) than other Python versions so it is not included
+#     # in the Docker image being used. There is also a technical issue to install Python 3.6 on
+#     # Ubuntu 20.04. See also SPARK-33162.
+#     - name: Install Python packages (Python 3.6)
+#       run: |
+#         python3.6 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
+#         python3.6 -m pip list
+#     # Run the tests.
+#     - name: Run tests
+#       run: |
+#         mkdir -p ~/.m2
+#         ./dev/run-tests --parallelism 2 --modules "$MODULES_TO_TEST"
+#         rm -rf ~/.m2/repository/org/apache/spark
+#     - name: Upload test results to report
+#       if: always()
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: test-results-${{ matrix.modules }}--1.8-hadoop3.2-hive2.3
+#         path: "**/target/test-reports/*.xml"
+#     - name: Upload unit tests log files
+#       if: failure()
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: unit-tests-log-${{ matrix.modules }}--1.8-hadoop3.2-hive2.3
+#         path: "**/target/unit-tests.log"
 
-  sparkr:
-    name: Build modules - sparkr
-    runs-on: ubuntu-20.04
-    container:
-      image: dongjoon/apache-spark-github-action-image:20201025
-    env:
-      HADOOP_PROFILE: hadoop3.2
-      HIVE_PROFILE: hive2.3
-      GITHUB_PREV_SHA: ${{ github.event.before }}
-      GITHUB_INPUT_BRANCH: ${{ github.event.inputs.target }}
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
-      with:
-        fetch-depth: 0
-    - name: Merge dispatched input branch
-      if: ${{ github.event.inputs.target != '' }}
-      run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache Scala, SBT, Maven and Zinc
-      uses: actions/cache@v2
-      with:
-        path: |
-          build/apache-maven-*
-          build/zinc-*
-          build/scala-*
-          build/*.jar
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
-        restore-keys: |
-          build-
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: sparkr-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          sparkr-maven-
-    - name: Cache Ivy local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.ivy2/cache
-        key: sparkr-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          sparkr-ivy-
-    - name: Run tests
-      run: |
-        mkdir -p ~/.m2
-        # The followings are also used by `r-lib/actions/setup-r` to avoid
-        # R issues at docker environment
-        export TZ=UTC
-        export _R_CHECK_SYSTEM_CLOCK_=FALSE
-        ./dev/run-tests --parallelism 2 --modules sparkr
-        rm -rf ~/.m2/repository/org/apache/spark
-    - name: Upload test results to report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-sparkr--1.8-hadoop3.2-hive2.3
-        path: "**/target/test-reports/*.xml"
+#   sparkr:
+#     name: Build modules - sparkr
+#     runs-on: ubuntu-20.04
+#     container:
+#       image: dongjoon/apache-spark-github-action-image:20201025
+#     env:
+#       HADOOP_PROFILE: hadoop3.2
+#       HIVE_PROFILE: hive2.3
+#       GITHUB_PREV_SHA: ${{ github.event.before }}
+#       GITHUB_INPUT_BRANCH: ${{ github.event.inputs.target }}
+#     steps:
+#     - name: Checkout Spark repository
+#       uses: actions/checkout@v2
+#       # In order to fetch changed files
+#       with:
+#         fetch-depth: 0
+#     - name: Merge dispatched input branch
+#       if: ${{ github.event.inputs.target != '' }}
+#       run: git merge --progress --ff-only origin/${{ github.event.inputs.target }}
+#     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+#     - name: Cache Scala, SBT, Maven and Zinc
+#       uses: actions/cache@v2
+#       with:
+#         path: |
+#           build/apache-maven-*
+#           build/zinc-*
+#           build/scala-*
+#           build/*.jar
+#         key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+#         restore-keys: |
+#           build-
+#     - name: Cache Maven local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.m2/repository
+#         key: sparkr-maven-${{ hashFiles('**/pom.xml') }}
+#         restore-keys: |
+#           sparkr-maven-
+#     - name: Cache Ivy local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.ivy2/cache
+#         key: sparkr-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+#         restore-keys: |
+#           sparkr-ivy-
+#     - name: Run tests
+#       run: |
+#         mkdir -p ~/.m2
+#         # The followings are also used by `r-lib/actions/setup-r` to avoid
+#         # R issues at docker environment
+#         export TZ=UTC
+#         export _R_CHECK_SYSTEM_CLOCK_=FALSE
+#         ./dev/run-tests --parallelism 2 --modules sparkr
+#         rm -rf ~/.m2/repository/org/apache/spark
+#     - name: Upload test results to report
+#       if: always()
+#       uses: actions/upload-artifact@v2
+#       with:
+#         name: test-results-sparkr--1.8-hadoop3.2-hive2.3
+#         path: "**/target/test-reports/*.xml"
 
-  # Static analysis, and documentation build
-  lint:
-    name: Linters, licenses, dependencies and documentation generation
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: docs-maven-repo-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          docs-maven-
-    - name: Install JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Install Python 3.6
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
-        architecture: x64
-    - name: Install Python linter dependencies
-      run: |
-        # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
-        #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
-        pip3 install flake8 'sphinx<3.1.0' numpy pydata_sphinx_theme ipython nbsphinx mypy numpydoc
-    - name: Install R 4.0
-      uses: r-lib/actions/setup-r@v1
-      with:
-        r-version: 4.0
-    - name: Install R linter dependencies and SparkR
-      run: |
-        sudo apt-get install -y libcurl4-openssl-dev
-        sudo Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
-        sudo Rscript -e "devtools::install_github('jimhester/lintr@v2.0.0')"
-        ./R/install-dev.sh
-    - name: Install Ruby 2.7 for documentation generation
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-    - name: Install dependencies for documentation generation
-      run: |
-        # pandoc is required to generate PySpark APIs as well in nbsphinx.
-        sudo apt-get install -y libcurl4-openssl-dev pandoc
-        # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
-        #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
-        pip install 'sphinx<3.1.0' mkdocs numpy pydata_sphinx_theme ipython nbsphinx numpydoc
-        gem install jekyll jekyll-redirect-from rouge
-        sudo Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'roxygen2'), repos='https://cloud.r-project.org/')"
-    - name: Scala linter
-      run: ./dev/lint-scala
-    - name: Java linter
-      run: ./dev/lint-java
-    - name: Python linter
-      run: ./dev/lint-python
-    - name: R linter
-      run: ./dev/lint-r
-    - name: License test
-      run: ./dev/check-license
-    - name: Dependencies test
-      run: ./dev/test-dependencies.sh
-    - name: Run documentation build
-      run: |
-        cd docs
-        jekyll build
+#   # Static analysis, and documentation build
+#   lint:
+#     name: Linters, licenses, dependencies and documentation generation
+#     runs-on: ubuntu-20.04
+#     steps:
+#     - name: Checkout Spark repository
+#       uses: actions/checkout@v2
+#     - name: Cache Maven local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.m2/repository
+#         key: docs-maven-repo-${{ hashFiles('**/pom.xml') }}
+#         restore-keys: |
+#           docs-maven-
+#     - name: Install JDK 1.8
+#       uses: actions/setup-java@v1
+#       with:
+#         java-version: 1.8
+#     - name: Install Python 3.6
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: 3.6
+#         architecture: x64
+#     - name: Install Python linter dependencies
+#       run: |
+#         # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
+#         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
+#         pip3 install flake8 'sphinx<3.1.0' numpy pydata_sphinx_theme ipython nbsphinx mypy numpydoc
+#     - name: Install R 4.0
+#       uses: r-lib/actions/setup-r@v1
+#       with:
+#         r-version: 4.0
+#     - name: Install R linter dependencies and SparkR
+#       run: |
+#         sudo apt-get install -y libcurl4-openssl-dev
+#         sudo Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+#         sudo Rscript -e "devtools::install_github('jimhester/lintr@v2.0.0')"
+#         ./R/install-dev.sh
+#     - name: Install Ruby 2.7 for documentation generation
+#       uses: actions/setup-ruby@v1
+#       with:
+#         ruby-version: 2.7
+#     - name: Install dependencies for documentation generation
+#       run: |
+#         # pandoc is required to generate PySpark APIs as well in nbsphinx.
+#         sudo apt-get install -y libcurl4-openssl-dev pandoc
+#         # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
+#         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
+#         pip install 'sphinx<3.1.0' mkdocs numpy pydata_sphinx_theme ipython nbsphinx numpydoc
+#         gem install jekyll jekyll-redirect-from rouge
+#         sudo Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'roxygen2'), repos='https://cloud.r-project.org/')"
+#     - name: Scala linter
+#       run: ./dev/lint-scala
+#     - name: Java linter
+#       run: ./dev/lint-java
+#     - name: Python linter
+#       run: ./dev/lint-python
+#     - name: R linter
+#       run: ./dev/lint-r
+#     - name: License test
+#       run: ./dev/check-license
+#     - name: Dependencies test
+#       run: ./dev/test-dependencies.sh
+#     - name: Run documentation build
+#       run: |
+#         cd docs
+#         jekyll build
 
-  java11:
-    name: Java 11 build
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: java11-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          java11-maven-
-    - name: Install Java 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Build with Maven
-      run: |
-        export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress"
-        mkdir -p ~/.m2
-        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=11 install
-        rm -rf ~/.m2/repository/org/apache/spark
+#   java11:
+#     name: Java 11 build
+#     runs-on: ubuntu-20.04
+#     steps:
+#     - name: Checkout Spark repository
+#       uses: actions/checkout@v2
+#     - name: Cache Maven local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.m2/repository
+#         key: java11-maven-${{ hashFiles('**/pom.xml') }}
+#         restore-keys: |
+#           java11-maven-
+#     - name: Install Java 11
+#       uses: actions/setup-java@v1
+#       with:
+#         java-version: 11
+#     - name: Build with Maven
+#       run: |
+#         export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+#         export MAVEN_CLI_OPTS="--no-transfer-progress"
+#         mkdir -p ~/.m2
+#         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=11 install
+#         rm -rf ~/.m2/repository/org/apache/spark
 
-  scala-213:
-    name: Scala 2.13 build
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-    - name: Cache Ivy local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.ivy2/cache
-        key: scala-213-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          scala-213-ivy-
-    - name: Install Java 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Build with SBT
-      run: |
-        ./dev/change-scala-version.sh 2.13
-        ./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Djava.version=11 -Pscala-2.13 compile test:compile
+#   scala-213:
+#     name: Scala 2.13 build
+#     runs-on: ubuntu-20.04
+#     steps:
+#     - name: Checkout Spark repository
+#       uses: actions/checkout@v2
+#     - name: Cache Ivy local repository
+#       uses: actions/cache@v2
+#       with:
+#         path: ~/.ivy2/cache
+#         key: scala-213-ivy-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+#         restore-keys: |
+#           scala-213-ivy-
+#     - name: Install Java 11
+#       uses: actions/setup-java@v1
+#       with:
+#         java-version: 11
+#     - name: Build with SBT
+#       run: |
+#         ./dev/change-scala-version.sh 2.13
+#         ./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Djava.version=11 -Pscala-2.13 compile test:compile

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Pull Request Labeler"
+on: pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,24 +1,24 @@
-name: Close stale PRs
+# name: Close stale PRs
 
-on:
-  schedule:
-  - cron: "0 0 * * *"
+# on:
+#   schedule:
+#   - cron: "0 0 * * *"
 
-jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/stale@v1.1.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: >
-          We're closing this PR because it hasn't been updated in a while.
-          This isn't a judgement on the merit of the PR in any way. It's just
-          a way of keeping the PR queue manageable.
+# jobs:
+#   stale:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/stale@v1.1.0
+#       with:
+#         repo-token: ${{ secrets.GITHUB_TOKEN }}
+#         stale-pr-message: >
+#           We're closing this PR because it hasn't been updated in a while.
+#           This isn't a judgement on the merit of the PR in any way. It's just
+#           a way of keeping the PR queue manageable.
 
-          If you'd like to revive this PR, please reopen it and ask a
-          committer to remove the Stale tag!
-        days-before-stale: 100
-        # Setting this to 0 is the same as setting it to 1.
-        # See: https://github.com/actions/stale/issues/28
-        days-before-close: 0
+#           If you'd like to revive this PR, please reopen it and ask a
+#           committer to remove the Stale tag!
+#         days-before-stale: 100
+#         # Setting this to 0 is the same as setting it to 1.
+#         # See: https://github.com/actions/stale/issues/28
+#         days-before-close: 0

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -1,24 +1,24 @@
-name: Report test results
-on:
-  workflow_run:
-    workflows: ["Build and test"]
-    types:
-      - completed
+# name: Report test results
+# on:
+#   workflow_run:
+#     workflows: ["Build and test"]
+#     types:
+#       - completed
 
-jobs:
-  test_report:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download test results to report
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: ${{ github.event.workflow_run.workflow_id }}
-        commit: ${{ github.event.workflow_run.head_commit.id }}
-    - name: Publish test report
-      uses: scacap/action-surefire-report@v1
-      with:
-        check_name: Report test results
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        report_paths: "**/target/test-reports/*.xml"
-        commit: ${{ github.event.workflow_run.head_commit.id }}
+# jobs:
+#   test_report:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - name: Download test results to report
+#       uses: dawidd6/action-download-artifact@v2
+#       with:
+#         github_token: ${{ secrets.GITHUB_TOKEN }}
+#         workflow: ${{ github.event.workflow_run.workflow_id }}
+#         commit: ${{ github.event.workflow_run.head_commit.id }}
+#     - name: Publish test report
+#       uses: scacap/action-surefire-report@v1
+#       with:
+#         check_name: Report test results
+#         github_token: ${{ secrets.GITHUB_TOKEN }}
+#         report_paths: "**/target/test-reports/*.xml"
+#         commit: ${{ github.event.workflow_run.head_commit.id }}

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -36,6 +36,9 @@ import org.apache.spark.sql.execution.arrow.ArrowConverters
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.DataType
 
+/**
+ * Random comment to test PR labeler.
+ */
 private[sql] object PythonSQLUtils extends Logging {
   def parseDataType(typeText: String): DataType = CatalystSqlParser.parseDataType(typeText)
 


### PR DESCRIPTION
I ran this test after commenting out BUILD.

However, the only reason it was labeled `SQL` and `CORE` is because of the previous `!/core/foo` tags (and same for `SQL`).

This shows that we need the use of the `any` function. However, as outlined in the other repo, `any` is not yet GA (and was not working properly when running off of the `main` branch).

I will open a ticket with the `actions/labeler` team about a potential timeline for cutting a stable release that has proper support for `any` and `all`.