### PR TITLE
[SPARK-33282][local hotfix] Add subfolder matches for DSTREAM globs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -100,7 +100,6 @@ AVRO:
 DSTREAM:
   - "/streaming/**/*"
   - "/data/streaming/**/*"
-  - "/external/flume*/**/*"
   - "/external/kinesis*/**/*"
   - "/external/kafka*/**/*"
   - "/python/pyspark/streaming/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -100,9 +100,9 @@ AVRO:
 DSTREAM:
   - "/streaming/**/*"
   - "/data/streaming/**/*"
-  - "/external/flume*"
-  - "/external/kinesis*"
-  - "/external/kafka*"
+  - "/external/flume*/**/*"
+  - "/external/kinesis*/**/*"
+  - "/external/kafka*/**/*"
   - "/python/pyspark/streaming/**/*"
 GRAPHX:
   - "/graphx/**/*"


### PR DESCRIPTION
As mentioned in https://github.com/kbendick/spark/pull/17, some of the DSTREAM globs end in a single wildcard, such as `/external/kafka*`, in order to match things like `/external/kafka-0-10-sql/....` as well as `/external/kafka-0-10-assembly/...`.

The currently proposed config failed to match on a change made to a file nested well below `/external/kafka-0-10-sql`, so I'm adding some additional subfolder globs to then retry the match.