### PR TITLE
[SPARK-33282][hotfix] Add leading globs to SS match **/sql/**/streaming

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -114,7 +114,7 @@ MLLIB:
   - "mllib-local/**/*"
   - "python/pyspark/mllib/**/*"
 STRUCTURED STREAMING:
-  - "sql/**/streaming/**/*"  # TODO - Does this one need a leading **/ or */ ?
+  - "**/sql/**/streaming/**/*"
   - "external/kafka-0-10-sql/**/*"
   - "python/pyspark/sql/streaming.py"
   - "python/pyspark/sql/tests/test_streaming.py"


### PR DESCRIPTION
This PR should arguably have been labeled `STRUCTURED STREAMING`, but it wasn't bc it's only considering entries that start with `sql` for the rule `sql/**/streaming/**/*`. I'm adding a leading `**`  to indicate that any subdirectory should match.